### PR TITLE
dateOnly, username 요청값으로 받아오지 않도록 수정

### DIFF
--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -21,6 +21,15 @@ export class RoomsService {
     return new Date(stringDate);
   }
 
+  async getRoomInfo(code: string): Promise<boolean> {
+    const roomInfo = await this.prismaService.room.findUnique({
+      where: { code },
+    });
+    //만약 방이 없다면 예외처리를 어떻게 해야 할까요??
+    const dateOnly = roomInfo.dateOnly;
+    return dateOnly;
+  }
+
   /**
    * 이 부분 상세 조건들은 아래 슬랙을 참고하시면 좋습니다
    * @see {@link https://www.notion.so/likelion-11th/6-6-8fdfd4c7268e4f70bd232dcee5078aab?pvs=4#ca12b4cd60904410bbb83549e748f1cd | Notion}

--- a/src/api/rooms/rooms.service.ts
+++ b/src/api/rooms/rooms.service.ts
@@ -21,15 +21,6 @@ export class RoomsService {
     return new Date(stringDate);
   }
 
-  async getRoomInfo(code: string): Promise<boolean> {
-    const roomInfo = await this.prismaService.room.findUnique({
-      where: { code },
-    });
-    //만약 방이 없다면 예외처리를 어떻게 해야 할까요??
-    const dateOnly = roomInfo.dateOnly;
-    return dateOnly;
-  }
-
   /**
    * 이 부분 상세 조건들은 아래 슬랙을 참고하시면 좋습니다
    * @see {@link https://www.notion.so/likelion-11th/6-6-8fdfd4c7268e4f70bd232dcee5078aab?pvs=4#ca12b4cd60904410bbb83549e748f1cd | Notion}

--- a/src/api/users/dto/create-appointment.dto.ts
+++ b/src/api/users/dto/create-appointment.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 
 export class CreateAppointmentDto {
   @IsString()

--- a/src/api/users/dto/update-user.dto.ts
+++ b/src/api/users/dto/update-user.dto.ts
@@ -1,13 +1,6 @@
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserDto {
-  @IsString()
-  username: string;
-
-  @IsOptional()
-  @IsBoolean()
-  dateOnly: boolean;
-
   @IsString({ each: true })
   dates: string[];
 }

--- a/src/api/users/users.controller.ts
+++ b/src/api/users/users.controller.ts
@@ -5,15 +5,13 @@ import {
   Patch,
   UseGuards,
   Param,
-  Get,
-  Query,
+  Request,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 import { UsersService } from './users.service';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { GetUserNameDto } from './dto/get-user-name.dto';
 
 @Controller('users')
 export class UsersController {
@@ -27,9 +25,11 @@ export class UsersController {
   @UseGuards(AuthGuard('jwt'))
   @Patch(':roomCode')
   update(
+    @Request() req,
     @Param('roomCode') roomCode: string,
     @Body() updateUserDto: UpdateUserDto
   ) {
-    return this.usersService.update(roomCode, updateUserDto);
+    const user = req.user;
+    return this.usersService.update(user, roomCode, updateUserDto);
   }
 }


### PR DESCRIPTION
https://mjulikelion11th.slack.com/archives/C053JFTFV5J/p1692633946592789
이 피드백 토대로 수정 완료 했습니다.

dateOnly는 DB를 통해, username은 토큰을 통해 받아오도록 수정했습니다.